### PR TITLE
feat(php-hyperf): add arm-dev variant with per-entry platforms

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -134,7 +134,8 @@ jobs:
                 tag: ($ver + (if (.suffix // "") == "" then "" else "-" + .suffix end)),
                 context: $ctx,
                 target: .target,
-                build_args: ((.args // {}) | to_entries | map(.key + "=" + (.value | tostring)) | join("\n"))
+                build_args: ((.args // {}) | to_entries | map(.key + "=" + (.value | tostring)) | join("\n")),
+                platforms: (.platforms // "linux/amd64")
               }
             ' <<< "$entries")
           done
@@ -158,6 +159,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -173,7 +177,7 @@ jobs:
           context: ./${{ matrix.build.context }}
           target: ${{ matrix.build.target }}
           build-args: ${{ matrix.build.build_args }}
-          platforms: linux/amd64
+          platforms: ${{ matrix.build.platforms }}
           push: true
           tags: devitools/${{ matrix.build.image }}:${{ matrix.build.tag }}
           cache-from: type=gha,scope=${{ matrix.build.image }}-${{ matrix.build.tag }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -74,6 +74,13 @@ jobs:
               errors=$((errors+1))
             fi
 
+            bad_platforms=$(jq -c '[.[] | select(has("platforms") and (.platforms | type) != "string")]' <<< "$entries")
+            if [ "$(jq 'length' <<< "$bad_platforms")" != "0" ]; then
+              echo "::error file=${manifest}::'platforms' must be a string when present (e.g. 'linux/amd64' or 'linux/amd64,linux/arm64'):"
+              jq -r '.[] | "  - " + (. | tostring)' <<< "$bad_platforms"
+              errors=$((errors+1))
+            fi
+
             if [ ! -f "$dockerfile" ]; then
               echo "::error file=${manifest}::sibling Dockerfile not found at ${dockerfile}"
               errors=$((errors+1))

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -74,9 +74,14 @@ jobs:
               errors=$((errors+1))
             fi
 
-            bad_platforms=$(jq -c '[.[] | select(has("platforms") and (.platforms | type) != "string")]' <<< "$entries")
+            bad_platforms=$(jq -c '[.[] | select(
+              has("platforms") and (
+                (.platforms | type) != "string" or
+                (.platforms | length) == 0
+              )
+            )]' <<< "$entries")
             if [ "$(jq 'length' <<< "$bad_platforms")" != "0" ]; then
-              echo "::error file=${manifest}::'platforms' must be a string when present (e.g. 'linux/amd64' or 'linux/amd64,linux/arm64'):"
+              echo "::error file=${manifest}::'platforms' must be a non-empty string when present (e.g. 'linux/amd64' or 'linux/amd64,linux/arm64'):"
               jq -r '.[] | "  - " + (. | tostring)' <<< "$bad_platforms"
               errors=$((errors+1))
             fi

--- a/php-hyperf/8.3/variants.yaml
+++ b/php-hyperf/8.3/variants.yaml
@@ -4,6 +4,11 @@
   target: hyperf
   args:
     APP_TARGET: dev
+- suffix: arm-dev
+  target: hyperf
+  args:
+    APP_TARGET: dev
+  platforms: linux/arm64
 - suffix: otel
   target: hyperf-otel
   args:


### PR DESCRIPTION
## Summary
- Adds an `arm-dev` variant of `devitools/php-hyperf:8.3` so Apple Silicon dev environments can pull a native arm64 image instead of running the amd64 `:8.3-dev` under Rosetta/QEMU emulation.
- Generalizes the `variants.yaml` schema with an optional `platforms` field (string, defaults to `linux/amd64`). Each entry can now opt into a different platform string (`linux/arm64`, `linux/amd64,linux/arm64`, etc.) without duplicating workflow logic.
- Sets up QEMU in the build workflow so the GHA amd64 runner can cross-build arm64.

## Why
`quoteguide-functions` has a `compose.override.yml` that swaps the dev image for a hand-built arm tag (`devitools/hyperf:8.3-arm-dev` previously pushed manually). Publishing it as a first-class variant means:
- No more manual push out-of-band; the pipeline owns the tag.
- The override file just needs to reference the published tag.
- Other Apple Silicon consumers get the same benefit.

Keeping arm-dev as a **separate tag** (rather than making `:8.3-dev` multi-arch) was chosen because:
- arm-dev is only useful for local dev — pushing to production never lands on arm.
- A separate tag avoids doubling the build time of every other variant.
- It keeps the lean/otel/google production tags strictly amd64, matching where they actually run.

## variants.yaml change

```yaml
- suffix: arm-dev
  target: hyperf
  args:
    APP_TARGET: dev
  platforms: linux/arm64
```

## Schema rule

`platforms` is **optional**. When omitted, the build defaults to `linux/amd64` (current behavior — no change for `aws-cli`, `node`, `quasar`, `vue`, or any existing image without a manifest). When present, it must be a string. `validate.yml` enforces the type at PR time.

## Tags produced from this PR (delta)

| Target | Args | Platforms | Tag |
|---|---|---|---|
| `hyperf` | `APP_TARGET=dev` | `linux/arm64` | `devitools/php-hyperf:8.3-arm-dev` |

Plus the matching `devitools/php-hyperf:latest-arm-dev` via the `php-hyperf/latest` symlink.

## Workflow changes
- New step `Set up QEMU` (`docker/setup-qemu-action@v3`) registers binfmt handlers so the amd64 runner can cross-build for `linux/arm64`.
- The detect job now serializes `platforms` (with `linux/amd64` default) into each matrix entry.
- The build step replaces the hardcoded `platforms: linux/amd64` with `${{ matrix.build.platforms }}`.

## Local validation
- `yq + jq` parser produces 5 matrix entries from the updated manifest (lean, dev, arm-dev, otel, google) with correct `platforms` values.
- `docker build --platform=linux/arm64 --target hyperf --build-arg APP_TARGET=dev` succeeds natively on an Apple Silicon Mac.
- `validate.yml`'s new `platforms` type check accepts strings and rejects non-strings (smoke-tested with a fake numeric value).

## Test plan
- [ ] PR triggers `validate.yml`; passes (manifest is valid).
- [ ] Merge triggers `build-images.yml` with the matrix expanded to 5 builds for `php-hyperf/8.3` + 5 for `php-hyperf/latest`.
- [ ] `devitools/php-hyperf:8.3-arm-dev` pull on an Apple Silicon host shows `linux/arm64` (no `amd64` warning from Docker).
- [ ] `devitools/php-hyperf:8.3-dev` pull on amd64 host still works (no regression).
- [ ] Existing variants without `platforms:` in their manifests continue to build as `linux/amd64`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 (linux/arm64) support for PHP Hyperf 8.3 builds, enabling deployments on ARM-based architectures.

* **Infrastructure**
  * Enhanced build system with cross-platform build capabilities and improved variant validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->