### PR TITLE
chore(actions): pin all workflow uses to commit SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      docker-actions:
+        patterns:
+          - "docker/*"
+      actions-org:
+        patterns:
+          - "actions/*"
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -27,12 +27,12 @@ jobs:
       builds: ${{ steps.list.outputs.builds }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Get changed files
         id: changed
         if: github.event_name == 'push'
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@2d756ea4c53f7f6b397767d8723b3a10a9f35bf2 # v44.0.0
 
       - name: Build matrix
         id: list
@@ -157,22 +157,22 @@ jobs:
         build: ${{ fromJson(needs.detect.outputs.builds) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./${{ matrix.build.context }}
           target: ${{ matrix.build.target }}

--- a/.github/workflows/copilot-sandbox.yml
+++ b/.github/workflows/copilot-sandbox.yml
@@ -21,16 +21,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -46,7 +46,7 @@ jobs:
             type=sha,prefix=,format=short
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./copilot-sandbox
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Get changed variants.yaml files
         id: changed
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@2d756ea4c53f7f6b397767d8723b3a10a9f35bf2 # v44.0.0
         with:
           files: '*/*/variants.yaml'
 


### PR DESCRIPTION
## Summary
Pins every GitHub Action reference in this repo's workflows to an immutable commit SHA, and adds a Dependabot config so the pins stay current automatically.

This applies the SHA-pinning hardening that CodeRabbit has been flagging on the last two PRs ([PR #2](https://github.com/devitools/dockerfile/pull/2) and [PR #3](https://github.com/devitools/dockerfile/pull/3)) — addressed here as a single repo-wide change instead of step-by-step, which is the right granularity for a security policy.

## Why
Tags like `@v3` are mutable. If an action's maintainer account is compromised, the attacker can retarget the tag to point at malicious code, and every workflow using that tag will execute it on the next run with access to repo secrets (e.g. `DOCKERHUB_TOKEN`). This is what happened in the `tj-actions/changed-files` incident (March 2025) and a few others since. Pinning to a full commit SHA makes the reference content-addressed — the SHA cannot point at different code without changing.

Doing it per-step would leave the rest of the file inconsistent and not actually close the attack surface. Doing it repo-wide + automated keeps it sustainable.

## Pin format

Each `uses:` keeps the original semver tag as an inline comment so Dependabot can recognize and update both halves:

```yaml
- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
```

## Pinned references (7 actions, 14 occurrences across 3 workflows)

| Action | Tag | SHA |
|---|---|---|
| `actions/checkout` | `v4.3.1` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `docker/setup-qemu-action` | `v3.7.0` | `c7c53464625b32c7a7e944ae62b3e17d2b600130` |
| `docker/setup-buildx-action` | `v3.12.0` | `8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` |
| `docker/login-action` | `v3.7.0` | `c94ce9fb468520275223c153574b00df6fe4bcc9` |
| `docker/metadata-action` | `v5.10.0` | `c299e40c65443455700f0fdfc63efafe5b349051` |
| `docker/build-push-action` | `v6.19.2` | `10e90e3645eae34f1e60eeb005ba3a3d33f178e8` |
| `tj-actions/changed-files` | `v44.0.0` | `2d756ea4c53f7f6b397767d8723b3a10a9f35bf2` |

Each SHA was resolved against the action's repo via the GitHub API at PR time.

## Dependabot config

Adds `.github/dependabot.yml` with the `github-actions` ecosystem and weekly grouped updates:

- `docker-actions` group: all `docker/*` actions bundled into one PR
- `actions-org` group: all `actions/*` actions bundled into one PR
- Other actions (e.g. `tj-actions/changed-files`) get individual PRs

Grouping limits PR noise while keeping related Docker-org actions versioned together (since they're often updated in sync).

## Test plan
- [ ] Workflows still parse (`yq eval` smoke-tested all four files locally)
- [ ] `validate.yml` runs on this PR and passes
- [ ] No build matrix entries are affected — only the `uses:` step references change
- [ ] Dependabot picks up the config after merge and opens its first PR within the next weekly cycle